### PR TITLE
Fix missing final STDIN newline when spawning ImageOptim

### DIFF
--- a/tasks/imageoptim.js
+++ b/tasks/imageoptim.js
@@ -183,7 +183,7 @@ module.exports = function(grunt) {
     });
 
     imageOptimCli.stdin.setEncoding('utf8');
-    imageOptimCli.stdin.end(files.join('\n'));
+    imageOptimCli.stdin.end(files.join('\n') + '\n');
 
     return deferred.promise;
 


### PR DESCRIPTION
When providing a list of paths to ImageOptim as a list separated by newlines, the last file is never processed because the final newline is missing.
